### PR TITLE
fix: avoid duplicate thinking labels on compatible forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Made thinking-label patching auto-disable on compatible forks that already provide core interaction summaries, avoiding duplicate `Thinking:` presentation while remaining silent on standard Pi.
+
 ## [0.1.8] - 2026-03-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ The extension checks the current Pi environment and adjusts behavior automatical
 
 - **MCP tooling unavailable**: MCP settings are hidden and MCP output is forced off
 - **RTK optimizer unavailable**: RTK hint settings are hidden and RTK compaction hints are disabled
+- **Compatible fork core summaries detected**: duplicate thinking-label patching is skipped automatically so built-in fork summaries remain the single source of truth
 
 This keeps the UI aligned with what the current environment can actually support.
 

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -1,4 +1,8 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import {
+  AssistantMessageComponent,
+  SettingsManager,
+  type ExtensionAPI,
+} from "@mariozechner/pi-coding-agent";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -7,6 +11,7 @@ import type { ToolDisplayConfig } from "./types.js";
 export interface ToolDisplayCapabilities {
 	hasMcpTooling: boolean;
 	hasRtkOptimizer: boolean;
+	hasCoreInteractionSummaries: boolean;
 }
 
 function toRecord(value: unknown): Record<string, unknown> {
@@ -74,10 +79,33 @@ function hasRtkExtensionPath(cwd: string): boolean {
 	return false;
 }
 
+export function detectCoreInteractionSummaries(): boolean {
+	try {
+		const hasToolDescriptionSetting =
+			typeof (SettingsManager as unknown as { prototype?: Record<string, unknown> })?.prototype
+				?.getHideToolDescriptions === "function";
+		const updateContent = (
+			AssistantMessageComponent as unknown as {
+				prototype?: { updateContent?: unknown };
+			}
+		)?.prototype?.updateContent;
+
+		if (!hasToolDescriptionSetting || typeof updateContent !== "function") {
+			return false;
+		}
+
+		const source = Function.prototype.toString.call(updateContent);
+		return source.includes("summarizeThinkingContent") || source.includes("Thinking: ${summary}");
+	} catch {
+		return false;
+	}
+}
+
 export function detectToolDisplayCapabilities(pi: ExtensionAPI, cwd: string): ToolDisplayCapabilities {
 	return {
 		hasMcpTooling: hasMcpTooling(pi),
 		hasRtkOptimizer: hasRtkCommand(pi) || hasRtkExtensionPath(cwd),
+		hasCoreInteractionSummaries: detectCoreInteractionSummaries(),
 	};
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export default function toolDisplayExtension(pi: ExtensionAPI): void {
   let capabilities: ToolDisplayCapabilities = {
     hasMcpTooling: false,
     hasRtkOptimizer: false,
+    hasCoreInteractionSummaries: false,
   };
 
   const refreshCapabilities = (): void => {
@@ -74,7 +75,9 @@ export default function toolDisplayExtension(pi: ExtensionAPI): void {
   registerToolDisplayOverrides(pi, getEffectiveConfig);
   registerNativeUserMessageBox(pi, getConfig);
   registerToolDisplayCommand(pi, { getConfig, setConfig, getCapabilities });
-  registerThinkingLabeling(pi);
+  registerThinkingLabeling(pi, {
+    enabled: () => !getCapabilities().hasCoreInteractionSummaries,
+  });
 
   pi.on("session_start", async (_event, ctx) => {
     refreshCapabilities();

--- a/src/thinking-label.ts
+++ b/src/thinking-label.ts
@@ -298,12 +298,23 @@ function handleThinkingContextEvent(event: unknown, ctx: ExtensionContext | unde
   }
 }
 
-export function registerThinkingLabeling(pi: ExtensionAPI): void {
+export function registerThinkingLabeling(
+  pi: ExtensionAPI,
+  options: { enabled?: () => boolean } = {},
+): void {
+  const isEnabled = (): boolean => options.enabled?.() ?? true;
+
   pi.on("message_update", async (event, ctx) => {
+    if (!isEnabled()) {
+      return;
+    }
     handleThinkingMessageUpdateEvent(event, ctx);
   });
 
   pi.on("message_end", async (event, ctx) => {
+    if (!isEnabled()) {
+      return;
+    }
     handleThinkingMessageEndEvent(event, ctx);
   });
 

--- a/tests/tool-ui-utils.test.ts
+++ b/tests/tool-ui-utils.test.ts
@@ -22,6 +22,7 @@ import {
   buildCollapsedDiffHintText,
   clampRenderedLineToWidth,
 } from "../src/line-width-safety.ts";
+import { detectCoreInteractionSummaries } from "../src/capabilities.ts";
 
 const codePointWidthOps = {
   measure: (text: string): number => [...text].length,
@@ -198,3 +199,7 @@ test("line width clamp never returns text wider than the requested width", () =>
   assert.equal(clampRenderedLineToWidth("hello", 0, codePointWidthOps), "");
 });
 
+test("core interaction summary capability detection does not throw", () => {
+  assert.doesNotThrow(() => detectCoreInteractionSummaries());
+  assert.equal(typeof detectCoreInteractionSummaries(), "boolean");
+});


### PR DESCRIPTION
## Summary
- detect compatible core interaction-summary implementations
- skip duplicate thinking-label patching when the core already owns that presentation
- keep behavior unchanged on standard Pi and leave context sanitization intact

## Details
This patch extends the existing capability-detection pattern instead of hardcoding fork behavior into renderers.

When the runtime exposes the newer core interaction-summary feature set, `pi-tool-display` now avoids layering its own final/display `Thinking:` labels on top of the built-in summaries. On standard Pi, the detector returns false and the extension behaves exactly as before.

The compatibility check is intentionally conservative and silent:
- no new required config
- no runtime errors if the fork-only hooks are absent
- no change to MCP/RTK capability behavior

## Validation
- `npm run check`
