### PR TITLE
fix(pi-tool-display): restore native user message box spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Restored native user message box spacing on recent Pi releases by extracting markdown through the newer nested `Box` wrapper and stripping OSC 133 prompt markers from fallback content normalization
+
 ## [0.3.2] - 2026-04-15
 
 ### Added

--- a/src/user-message-box-markdown.ts
+++ b/src/user-message-box-markdown.ts
@@ -31,11 +31,29 @@ function isMarkdownLike(value: unknown): value is MarkdownLike {
   return isRecord(value) && typeof value.text === "string" && value.theme !== undefined;
 }
 
+function findMarkdownChild(value: unknown): MarkdownLike | undefined {
+  if (isMarkdownLike(value)) {
+    return value;
+  }
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const children = Array.isArray(value.children) ? value.children : [];
+  for (const child of children) {
+    const markdownChild = findMarkdownChild(child);
+    if (markdownChild) {
+      return markdownChild;
+    }
+  }
+
+  return undefined;
+}
+
 export function extractUserMessageMarkdownState(
   userMessage: UserMessageLike,
 ): UserMessageMarkdownState | undefined {
-  const children = Array.isArray(userMessage.children) ? userMessage.children : [];
-  const markdownChild = children.find((child) => isMarkdownLike(child));
+  const markdownChild = findMarkdownChild(userMessage);
   if (!markdownChild || typeof markdownChild.text !== "string") {
     return undefined;
   }

--- a/src/user-message-box-utils.ts
+++ b/src/user-message-box-utils.ts
@@ -1,4 +1,5 @@
-const ANSI_ESCAPE_PATTERN = /\x1b\[([0-9;]*)m/g;
+const SGR_ESCAPE_PATTERN = /\x1b\[([0-9;]*)m/g;
+const OSC_ESCAPE_PATTERN = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
 const STYLE_RESET_PARAMS = [39, 22, 23, 24, 25, 27, 28, 29, 59] as const;
 const USER_MESSAGE_BACKGROUND = "userMessageBg";
 const ANSI_BG_RESET = "\x1b[49m";
@@ -60,12 +61,21 @@ function sanitizeSgrParams(params: number[]): number[] {
   return sanitized;
 }
 
-function sanitizeAnsiForThemedOutput(text: string): string {
-  if (!text || !text.includes("\x1b[")) {
+function stripOscSequences(text: string): string {
+  if (!text || !text.includes("\x1b]")) {
     return text;
   }
 
-  return text.replace(ANSI_ESCAPE_PATTERN, (_sequence, rawParams: string) => {
+  return text.replace(OSC_ESCAPE_PATTERN, "");
+}
+
+function sanitizeAnsiForThemedOutput(text: string): string {
+  const withoutOsc = stripOscSequences(text);
+  if (!withoutOsc || !withoutOsc.includes("\x1b[")) {
+    return withoutOsc;
+  }
+
+  return withoutOsc.replace(SGR_ESCAPE_PATTERN, (_sequence, rawParams: string) => {
     const parsed = toSgrParams(rawParams);
     if (parsed.length === 0) {
       return "";
@@ -111,8 +121,10 @@ export function applyUserMessageBackground(
 }
 
 function isVisuallyEmptyLine(line: string): boolean {
-  const withoutAnsi = line.replace(ANSI_ESCAPE_PATTERN, "");
-  return withoutAnsi.trim().length === 0;
+  const withoutControlSequences = line
+    .replace(OSC_ESCAPE_PATTERN, "")
+    .replace(SGR_ESCAPE_PATTERN, "");
+  return withoutControlSequences.trim().length === 0;
 }
 
 function trimEdgePadding(lines: string[]): string[] {

--- a/tests/tool-ui-utils.test.ts
+++ b/tests/tool-ui-utils.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../src/user-message-box-markdown.ts";
 import {
   createUserMessageMarkdownLineRenderer,
+  patchNativeUserMessagePrototype,
   shouldBypassUserMessageMarkdownRebuild,
 } from "../src/user-message-box-renderer.ts";
 import {
@@ -113,6 +114,32 @@ test("user message markdown extraction removes nested background styling", () =>
   assert.equal("bgColor" in (extracted?.defaultTextStyle ?? {}), false);
 });
 
+test("user message markdown extraction finds markdown nested inside the native box", () => {
+  const theme = { heading: () => "" };
+  const color = (text: string): string => text;
+  const extracted = extractUserMessageMarkdownState({
+    children: [
+      {
+        children: [
+          {
+            text: "Nested **markdown**",
+            theme,
+            defaultTextStyle: {
+              color,
+              bgColor: (text: string): string => text,
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(extracted?.text, "Nested **markdown**");
+  assert.equal(extracted?.theme, theme);
+  assert.equal(extracted?.defaultTextStyle?.color, color);
+  assert.equal("bgColor" in (extracted?.defaultTextStyle ?? {}), false);
+});
+
 test("user message markdown renderer reuses cached markdown renders for identical state", () => {
   let rendererCreationCount = 0;
   let renderCallCount = 0;
@@ -177,13 +204,30 @@ test("user message renderer adds one top and bottom padding row inside the box",
   assert.deepEqual(addUserMessageVerticalPadding(["Line 1", "Line 2"]), ["", "Line 1", "Line 2", ""]);
 });
 
+test("native user message renderer inserts one blank spacer line before the box", () => {
+  const prototype: PatchableUserMessagePrototype = {
+    render: () => ["Original user content"],
+  };
+
+  patchNativeUserMessagePrototype(prototype, () => undefined, () => true);
+
+  const rendered = prototype.render(24);
+
+  assert.equal(rendered[0], "");
+  assert.match(rendered[1] ?? "", /^╭/);
+});
+
 test("user message blank ansi lines are cleared before wrapping", () => {
   assert.equal(normalizeUserMessageContentLine("\u001b[0m"), "");
   assert.equal(normalizeUserMessageContentLine("   \u001b[31m\u001b[0m"), "");
+  assert.equal(normalizeUserMessageContentLine("\u001b]133;A\u0007   \u001b]133;B\u0007"), "");
 
   const normalized = normalizeUserMessageContentLine("\u001b[31mhello\u001b[0m");
   assert.match(normalized, /hello/);
   assert.doesNotMatch(normalized, /\u001b\[0m/);
+
+  const withoutOsc = normalizeUserMessageContentLine("\u001b]133;A\u0007hello\u001b]133;B\u0007");
+  assert.equal(withoutOsc, "hello");
 });
 
 test("user message background painting keeps trailing padding inside explicit background cells", () => {
@@ -220,6 +264,14 @@ test("user message content trims edge padding but preserves intentional interior
     "world",
   ]);
   assert.deepEqual(normalizeUserMessageContentLines(["\u001b[0m", "   "]), []);
+  assert.deepEqual(
+    normalizeUserMessageContentLines([
+      "\u001b]133;A\u0007   ",
+      "hello",
+      "\u001b]133;B\u0007\u001b]133;C\u0007   ",
+    ]),
+    ["hello"],
+  );
 });
 
 test("collapsed diff hint shrinks to fit narrow panes", () => {


### PR DESCRIPTION
After Pi ~0.67, the native `UserMessageComponent` changed in two ways: the `Markdown` child is now wrapped inside a `Box` container (rather than being a direct child), and the rendered output includes OSC 133 semantic prompt markers.  The extension's bordered user-message renderer relied on both the old flat structure and a purely-SGR ANSI stripping routine, so it stopped extracting the markdown body cleanly and started re-boxing Pi's own padded/OSC-marked output, producing an extra blank row above and below the message and a misaligned border.

This patch makes the markdown extraction walk nested children recursively and teaches the ANSI normalization layer to strip OSC escape sequences, so native padding lines carrying only prompt markers are correctly recognized as empty and trimmed.

Before patch:
<img width="900" alt="broke" src="https://github.com/user-attachments/assets/47dd41c9-e905-448a-8d04-54a8f5b937e0" />

After:
<img width="900" alt="bespoke" src="https://github.com/user-attachments/assets/490bcd20-30aa-4254-896f-3dd4d04e451d" />

Summary of changes:
- markdown extraction: replace flat `children.find()` with recursive `findMarkdownChild()` so the `Markdown` node is found inside the newer `Box → Markdown` component tree
- ANSI utils: add `OSC_ESCAPE_PATTERN` regex and `stripOscSequences()` helper; run it before SGR sanitization in `sanitizeAnsiForThemedOutput()` and in `isVisuallyEmptyLine()` so OSC 133 markers no longer prevent blank-line detection
- rename `ANSI_ESCAPE_PATTERN` → `SGR_ESCAPE_PATTERN` to distinguish it from the new OSC pattern
- tests: add nested-markdown extraction case, OSC-only blank line assertions, and edge-padding trimming with OSC 133 markers
- changelog: add unreleased fix entry