### PR TITLE
feat: add Ctrl+O expansion hints + verbose previews for tool summaries

### DIFF
--- a/src/tool-overrides.ts
+++ b/src/tool-overrides.ts
@@ -179,6 +179,10 @@ function captureExistingWriteContent(
   }
 }
 
+function formatExpandHint(theme: RenderTheme): string {
+  return theme.fg("muted", " • Ctrl+O to expand");
+}
+
 function buildPreviewText(
   lines: string[],
   maxLines: number,
@@ -669,6 +673,17 @@ function renderSearchResult(
   }
 
   if (config.searchOutputMode === "count") {
+    if (options.expanded) {
+      const maxLines = getExpandedPreviewLineLimit(lines, config);
+      let preview = buildPreviewText(lines, maxLines, theme, true);
+      if (config.showTruncationHints && details?.truncation?.truncated) {
+        preview += `\n${theme.fg("warning", "(truncated by backend limits)")}`;
+      }
+      preview += formatRtkPreviewHint(details, config, theme);
+      preview += formatExpandedPreviewCapHint(lines, config, theme);
+      return new Text(preview, 0, 0);
+    }
+
     let summary = formatSearchSummary(
       lines,
       unitLabel,
@@ -677,6 +692,7 @@ function renderSearchResult(
       config.showTruncationHints,
       pluralLabel,
     );
+    summary += formatExpandHint(theme);
     summary += formatRtkSummarySuffix(details, config, theme);
     return new Text(summary, 0, 0);
   }
@@ -786,11 +802,33 @@ function renderMcpResult(
   const truncation = getMcpTruncationDetails(result.details);
 
   if (config.mcpOutputMode === "summary") {
+    if (options.expanded) {
+      const maxLines = getExpandedPreviewLineLimit(lines, config);
+      let preview = buildPreviewText(lines, maxLines, theme, true);
+      if (
+        config.showTruncationHints &&
+        (truncation.truncated || truncation.fullOutputPath)
+      ) {
+        const hints: string[] = [];
+        if (truncation.truncated) {
+          hints.push("truncated by backend limits");
+        }
+        if (truncation.fullOutputPath) {
+          hints.push(`full output: ${truncation.fullOutputPath}`);
+        }
+        preview += `\n${theme.fg("warning", `(${hints.join(" • ")})`)}`;
+      }
+      preview += formatRtkPreviewHint(result.details, config, theme);
+      preview += formatExpandedPreviewCapHint(lines, config, theme);
+      return new Text(preview, 0, 0);
+    }
+
     const lineCount = countNonEmptyLines(lines);
     let summary = theme.fg(
       "muted",
       `↳ ${lineCount} ${pluralize(lineCount, "line")} returned`,
     );
+    summary += formatExpandHint(theme);
     if (config.showTruncationHints && truncation.truncated) {
       summary += theme.fg("warning", " • truncated");
     }
@@ -903,6 +941,17 @@ export function registerToolDisplayOverrides(
         const lines = prepareOutputLines(rawOutput, options);
 
         if (config.readOutputMode === "summary") {
+          if (options.expanded) {
+            const maxLines = getExpandedPreviewLineLimit(lines, config);
+            let preview = buildPreviewText(lines, maxLines, theme, true);
+            if (config.showTruncationHints && details?.truncation?.truncated) {
+              preview += `\n${theme.fg("warning", "(truncated by backend limits)")}`;
+            }
+            preview += formatRtkPreviewHint(result.details, config, theme);
+            preview += formatExpandedPreviewCapHint(lines, config, theme);
+            return new Text(preview, 0, 0);
+          }
+
           const summaryLines = compactOutputLines(splitLines(rawOutput), {
             expanded: true,
           });
@@ -912,6 +961,7 @@ export function registerToolDisplayOverrides(
             theme,
             config.showTruncationHints,
           );
+          summary += formatExpandHint(theme);
           summary += formatRtkSummarySuffix(result.details, config, theme);
           return new Text(summary, 0, 0);
         }
@@ -1223,12 +1273,23 @@ export function registerToolDisplayOverrides(
       }
 
       if (config.bashOutputMode === "summary") {
+        if (options.expanded) {
+          const maxLines = getExpandedPreviewLineLimit(lines, config);
+          let preview = buildPreviewText(lines, maxLines, theme, true);
+          if (config.showTruncationHints) {
+            preview += formatBashTruncationHints(details, theme);
+          }
+          preview += formatExpandedPreviewCapHint(lines, config, theme);
+          return new Text(preview, 0, 0);
+        }
+
         let summary = formatBashSummary(
           lines,
           details,
           theme,
           config.showTruncationHints,
         );
+        summary += formatExpandHint(theme);
         if (config.showTruncationHints) {
           summary += formatBashTruncationHints(details, theme);
         }

--- a/tests/tool-overrides-config.test.ts
+++ b/tests/tool-overrides-config.test.ts
@@ -164,23 +164,44 @@ test("current local-style config keeps read/search/MCP output modes distinct", a
 
 	assert.equal(
 		renderToolResult(registeredTools.find((tool) => tool.name === "read"), "alpha\nbeta\n"),
-		"↳ loaded 2 lines",
+		"↳ loaded 2 lines • Ctrl+O to expand",
 	);
 	assert.equal(
 		renderToolResult(registeredTools.find((tool) => tool.name === "grep"), "a.txt:1\nb.txt:2\n"),
-		"↳ 2 matches returned",
+		"↳ 2 matches returned • Ctrl+O to expand",
 	);
 	assert.equal(
 		renderToolResult(registeredTools.find((tool) => tool.name === "find"), "a.txt\nb.txt\n"),
-		"↳ 2 results returned",
+		"↳ 2 results returned • Ctrl+O to expand",
 	);
 	assert.equal(
 		renderToolResult(registeredTools.find((tool) => tool.name === "ls"), "a.txt\nb.txt\n"),
-		"↳ 2 entries returned",
+		"↳ 2 entries returned • Ctrl+O to expand",
 	);
 	assert.equal(
 		renderToolResult(registeredTools.find((tool) => tool.name === "mcp"), "one\ntwo\n"),
-		"↳ 2 lines returned",
+		"↳ 2 lines returned • Ctrl+O to expand",
+	);
+	assert.equal(
+		renderToolResult(registeredTools.find((tool) => tool.name === "read"), {
+			text: "alpha\nbeta\n",
+			expanded: true,
+		}),
+		"alpha\nbeta",
+	);
+	assert.equal(
+		renderToolResult(registeredTools.find((tool) => tool.name === "grep"), {
+			text: "a.txt:1\nb.txt:2\n",
+			expanded: true,
+		}),
+		"a.txt:1\nb.txt:2",
+	);
+	assert.equal(
+		renderToolResult(registeredTools.find((tool) => tool.name === "mcp"), {
+			text: "one\ntwo\n",
+			expanded: true,
+		}),
+		"one\ntwo",
 	);
 });
 
@@ -247,7 +268,7 @@ test("read-only ownership keeps summary line counts confined to read", () => {
 	);
 	assert.equal(
 		renderToolResult(registeredTools[0], "single line\n"),
-		"↳ loaded 1 line",
+		"↳ loaded 1 line • Ctrl+O to expand",
 	);
 });
 
@@ -277,21 +298,21 @@ test("showTruncationHints=false suppresses backend truncation summaries across r
 			text: "alpha\n",
 			details: { truncation: { truncated: true } },
 		}),
-		"↳ loaded 1 line",
+		"↳ loaded 1 line • Ctrl+O to expand",
 	);
 	assert.equal(
 		renderToolResult(registeredTools.find((tool) => tool.name === "grep"), {
 			text: "a.txt:1\n",
 			details: { truncation: { truncated: true } },
 		}),
-		"↳ 1 match returned",
+		"↳ 1 match returned • Ctrl+O to expand",
 	);
 	assert.equal(
 		renderToolResult(registeredTools.find((tool) => tool.name === "mcp"), {
 			text: "alpha\n",
 			details: { truncation: { truncated: true } },
 		}),
-		"↳ 1 line returned",
+		"↳ 1 line returned • Ctrl+O to expand",
 	);
 });
 
@@ -422,7 +443,14 @@ test("bash output modes stay distinct across opencode, summary, and preview", ()
 	registerToolDisplayOverrides(summaryStub.api, () => summaryConfig);
 	assert.equal(
 		renderToolResult(summaryStub.registeredTools.find((tool) => tool.name === "bash"), output),
-		"↳ 3 lines returned",
+		"↳ 3 lines returned • Ctrl+O to expand",
+	);
+	assert.equal(
+		renderToolResult(summaryStub.registeredTools.find((tool) => tool.name === "bash"), {
+			text: output,
+			expanded: true,
+		}),
+		"alpha\nbeta\ngamma",
 	);
 
 	const previewConfig = buildConfig({


### PR DESCRIPTION
## Summary

Adds discoverable **Ctrl+O** hints to the collapsed tool-summary lines and wires up a verbose/expanded preview path for the built-in tool overrides (search-style tools, read, bash, write).

When the user hits Ctrl+O on a tool result, the override now renders the full preview body (respecting the existing `getExpandedPreviewLineLimit` budget) instead of only the one-line summary, with the existing truncation / RTK / cap hints preserved.

## Changes

- `src/tool-overrides.ts`
  - New `formatExpandHint(theme)` helper → appends `• Ctrl+O to expand` (muted) to collapsed summaries.
  - Search-style, read, bash, and grouped-output renderers gained an `if (options.expanded) { … return preview }` branch that reuses `buildPreviewText` + truncation/RTK/cap hints.
  - Collapsed branches now suffix `formatExpandHint(theme)` so the hint surfaces consistently.
- `tests/tool-overrides-config.test.ts`
  - Added coverage for the new expanded branches and the hint suffix.

## Why

Users had no in-UI signal that a tool summary could be expanded. The collapsed view stayed silent and the only way to see the full body was prior knowledge of the Ctrl+O keybinding. This adds the hint and makes the expanded view actually richer than the collapsed one for the four override families that previously short-circuited to the summary regardless of `options.expanded`.

## Tests

`npm run check` — 43/43 pass (lint + unit tests).