### PR TITLE
fix: MCP tool render override silently failing for all server tools

### DIFF
--- a/src/tool-metadata.ts
+++ b/src/tool-metadata.ts
@@ -75,6 +75,13 @@ export function isMcpToolCandidate(tool: unknown): boolean {
 		return true;
 	}
 
+	// Detect context-mode tools (ctx_*) as MCP rendering candidates.
+	// These tools are registered by the context-mode MCP server and produce
+	// potentially large output that benefits from collapsed/summary display.
+	if (typeof name === "string" && name.startsWith("ctx_")) {
+		return true;
+	}
+
 	const description = getTextField(tool, "description");
 	return typeof description === "string" && MCP_DESCRIPTION_PATTERN.test(description);
 }

--- a/src/tool-overrides.ts
+++ b/src/tool-overrides.ts
@@ -1454,6 +1454,52 @@ export function registerToolDisplayOverrides(
 
   const wrappedMcpToolNames = new Set<string>();
 
+  // ---------------------------------------------------------------------------
+  // Capture full tool definitions (including execute) by intercepting
+  // pi.registerTool calls. Pi's getAllTools() only returns
+  // {name, description, parameters, sourceInfo} without execute/renderCall/
+  // renderResult, which made MCP tool override wrapping silently fail for all
+  // MCP server tools (including context-mode ctx_* tools).
+  //
+  // The interception works because each extension's pi.registerTool stores
+  // the full tool definition before calling refreshTools(). By wrapping our
+  // own pi.registerTool, we capture definitions from any extension that
+  // registers tools after pi-tool-display loads (including MCP adapter tools
+  // registered during session_start lifecycle).
+  // ---------------------------------------------------------------------------
+  const capturedFullDefinitions = new Map<string, RuntimeToolDefinition>();
+
+  const originalRegisterTool = pi.registerTool.bind(pi);
+  pi.registerTool = function (tool: RuntimeToolDefinition): void {
+    if (tool && typeof tool === "object") {
+      const toolName = (tool as Record<string, unknown>).name;
+      if (typeof toolName === "string") {
+        capturedFullDefinitions.set(toolName, tool);
+      }
+    }
+    originalRegisterTool(tool);
+  } as typeof pi.registerTool;
+
+  /**
+   * Resolve a tool candidate from getAllTools() by merging with any captured
+   * full definition. Captured definitions take priority because they include
+   * the execute function.
+   */
+  function resolveFullToolCandidate(
+    candidate: unknown,
+  ): { toolRecord: Record<string, unknown>; toolName: string } | null {
+    const toolName = getTextField(candidate, "name");
+    if (!toolName) return null;
+
+    const captured = capturedFullDefinitions.get(toolName);
+    if (captured) {
+      return { toolRecord: toRecord(captured), toolName };
+    }
+
+    // Fall back to getAllTools() result (works if Pi returns full definitions)
+    return { toolRecord: toRecord(candidate), toolName };
+  }
+
   const registerMcpToolOverrides = (): void => {
     let allTools: unknown[] = [];
     try {
@@ -1468,14 +1514,19 @@ export function registerToolDisplayOverrides(
         continue;
       }
 
-      const toolName = getTextField(candidate, "name");
-      if (!toolName || wrappedMcpToolNames.has(toolName)) {
+      const resolved = resolveFullToolCandidate(candidate);
+      if (!resolved) continue;
+      const { toolRecord, toolName } = resolved;
+
+      if (wrappedMcpToolNames.has(toolName)) {
         continue;
       }
 
-      const toolRecord = toRecord(candidate);
       const executeCandidate = toolRecord.execute;
       if (typeof executeCandidate !== "function") {
+        logToolDisplayDebug(
+          `MCP tool '${toolName}' has no execute function (captured=${capturedFullDefinitions.has(toolName)}), skipping render override.`,
+        );
         continue;
       }
 
@@ -1486,6 +1537,7 @@ export function registerToolDisplayOverrides(
           : undefined;
       const toolLabel =
         getTextField(candidate, "label") ||
+        getTextField(toolRecord, "label") ||
         (toolName === "mcp" ? "MCP Proxy" : `MCP ${toolName}`);
       const toolDescription =
         getTextField(candidate, "description") || "MCP tool";


### PR DESCRIPTION
## Problem

`registerMcpToolOverrides()` silently skips **ALL** MCP server tools (including context-mode `ctx_*` tools) because `pi.getAllTools()` only returns `{name, description, parameters, sourceInfo}` — no `execute` function.

This means the `mcpOutputMode` config (`summary`/`preview`/`hidden`) has **never worked** for MCP server tools. The check at line 1478:

```typescript
const executeCandidate = toolRecord.execute;
if (typeof executeCandidate !== "function") {
  continue;  // ← always hits this for MCP tools
}
```

## Root Cause

Pi's `AgentSession.getAllTools()` strips the full tool definition:

```javascript
getAllTools() {
  return Array.from(this._toolDefinitions.values())
    .map(({ definition, sourceInfo }) => ({
      name: definition.name,
      description: definition.description,
      parameters: definition.parameters,
      sourceInfo,
      // execute, renderCall, renderResult — all missing!
    }));
}
```

## Fix

1. **Intercept `pi.registerTool`** to capture full tool definitions (with `execute`) before the extension loader stores them
2. **Merge captured definitions** with `getAllTools()` results when wrapping MCP tools
3. **Add `ctx_*` detection** in `isMcpToolCandidate()` for context-mode tools that produce large output
4. **Add debug logging** when execute is still unavailable after capture
5. **Fall back gracefully** to `getAllTools()` result for future Pi versions that may return complete definitions

## Testing

- With `mcpOutputMode: "summary"`: ctx_* tools now show `↳ N lines returned • Ctrl+O to expand`
- With `mcpOutputMode: "preview"`: shows first N lines + expand hint
- With `mcpOutputMode: "hidden"`: completely hidden

## Note for Pi core

The ideal fix would be for Pi's `getAllTools()` to return full tool definitions. This extension-level workaround captures them via `registerTool` interception, which covers tools registered after pi-tool-display loads. Tools registered before pi-tool-display (unusual for MCP tools) would need Pi core changes.