### PR TITLE
Fix bash override to preserve shell settings

### DIFF
--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -24,7 +24,10 @@ function hasMcpTooling(pi: ExtensionAPI): boolean {
 function hasRtkCommand(pi: ExtensionAPI): boolean {
 	try {
 		const commands = pi.getCommands();
-		return commands.some((command) => command.name === "rtk" || command.name.startsWith("rtk-"));
+		return commands.some((command) => {
+			const name = typeof command.name === "string" ? command.name : undefined;
+			return name === "rtk" || name?.startsWith("rtk-") === true;
+		});
 	} catch (error) {
 		logToolDisplayDebug("RTK command capability detection failed.", error);
 		return false;

--- a/src/tool-overrides.ts
+++ b/src/tool-overrides.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import type {
   BashToolDetails,
   EditToolDetails,
@@ -20,6 +22,7 @@ import {
   formatSize,
 } from "@earendil-works/pi-coding-agent";
 import { Container, Spacer, Text } from "@earendil-works/pi-tui";
+import { resolvePiAgentDir } from "./agent-dir.js";
 import { renderBashCall } from "./bash-display.js";
 import { logToolDisplayDebug } from "./debug-logger.js";
 import { registerCleanup } from "./disposable.js";
@@ -109,6 +112,16 @@ export interface WriteExecutionMeta {
 interface PendingDiffPreviewState {
   key?: string;
   data?: PendingDiffPreviewData;
+}
+
+interface PiSettingsShellConfig {
+  shellPath?: unknown;
+  shellCommandPrefix?: unknown;
+}
+
+interface BashToolOverrideOptions {
+  shellPath?: string;
+  commandPrefix?: string;
 }
 
 const builtInToolCache = new Map<string, BuiltInTools>();
@@ -260,6 +273,28 @@ function clearBuiltInToolCache(): void {
   builtInToolCache.clear();
 }
 
+function getStringSetting(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function loadBashToolOverrideOptions(): BashToolOverrideOptions {
+  const settingsPath = join(resolvePiAgentDir(), "settings.json");
+  if (!existsSync(settingsPath)) {
+    return {};
+  }
+
+  try {
+    const rawSettings = JSON.parse(readFileSync(settingsPath, "utf-8")) as PiSettingsShellConfig;
+    return {
+      shellPath: getStringSetting(rawSettings.shellPath),
+      commandPrefix: getStringSetting(rawSettings.shellCommandPrefix),
+    };
+  } catch (error) {
+    logToolDisplayDebug("Failed to read Pi settings for bash tool overrides.", error);
+    return {};
+  }
+}
+
 function getBuiltInTools(cwd: string): BuiltInTools {
   let tools = builtInToolCache.get(cwd);
   if (!tools) {
@@ -282,7 +317,7 @@ function createLazyBuiltInTools(cwd: string): BuiltInTools {
     get grep() { return get("grep", () => createGrepTool(cwd)); },
     get find() { return get("find", () => createFindTool(cwd)); },
     get ls() { return get("ls", () => createLsTool(cwd)); },
-    get bash() { return get("bash", () => createBashTool(cwd)); },
+    get bash() { return get("bash", () => createBashTool(cwd, loadBashToolOverrideOptions())); },
     get edit() { return get("edit", () => createEditTool(cwd)); },
     get write() { return get("write", () => createWriteTool(cwd)); },
   } as BuiltInTools;

--- a/tests/tool-overrides-registration.test.ts
+++ b/tests/tool-overrides-registration.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import {
 	createBashTool,
@@ -29,6 +32,10 @@ interface RegisteredToolLike {
 interface ToolEventHandlers {
 	session_start?: () => Promise<void> | void;
 	before_agent_start?: () => Promise<void> | void;
+}
+
+interface ExecutableToolLike extends RegisteredToolLike {
+	execute: (...args: unknown[]) => Promise<{ content?: Array<{ type: string; text?: string }> }>;
 }
 
 function withDefaultReadEditOwners(tools: unknown[] = []): unknown[] {
@@ -63,6 +70,22 @@ function createExtensionApiStub(allTools: unknown[] = []): {
 	} as unknown as ExtensionAPI;
 
 	return { api, registeredTools, eventHandlers };
+}
+
+async function withTempDir(name: string, run: (dir: string) => Promise<void> | void): Promise<void> {
+	const dir = mkdtempSync(join(tmpdir(), name));
+	try {
+		await run(dir);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+function getTextOutput(result: { content?: Array<{ type: string; text?: string }> }): string {
+	return (result.content ?? [])
+		.filter((entry) => entry.type === "text")
+		.map((entry) => entry.text ?? "")
+		.join("");
 }
 
 test("registerToolDisplayOverrides copies built-in prompt metadata onto overridden tools", async () => {
@@ -163,6 +186,73 @@ test("registerToolDisplayOverrides leaves externally owned read/edit/grep tools 
 	assert.equal(registeredNames.has("ls"), true);
 	assert.equal(registeredNames.has("bash"), true);
 	assert.equal(registeredNames.has("write"), true);
+});
+
+test("bash override uses shellPath from Pi settings", async () => {
+	await withTempDir("pi-tool-display-shellpath-", async (dir) => {
+		const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		process.env.PI_CODING_AGENT_DIR = dir;
+		writeFileSync(
+			join(dir, "settings.json"),
+			JSON.stringify({ shellPath: "/definitely/missing/bash" }),
+			"utf8",
+		);
+
+		try {
+			const { api, registeredTools, eventHandlers } = createExtensionApiStub();
+			registerToolDisplayOverrides(api, () => DEFAULT_TOOL_DISPLAY_CONFIG);
+			await eventHandlers.before_agent_start?.();
+
+			const bashTool = registeredTools.find((tool) => tool.name === "bash") as ExecutableToolLike | undefined;
+			assert.ok(bashTool, "expected bash override to be registered");
+			await assert.rejects(
+				bashTool.execute("tool-call-1", { command: "printf test" }, undefined, undefined, { cwd: process.cwd() }),
+				/custom shell path not found/i,
+			);
+			assert.equal(bashTool.description.length > 0, true);
+		} finally {
+			if (previousAgentDir === undefined) {
+				delete process.env.PI_CODING_AGENT_DIR;
+			} else {
+				process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+			}
+		}
+	});
+});
+
+test("bash override uses shellCommandPrefix from Pi settings", async () => {
+	await withTempDir("pi-tool-display-shellprefix-", async (dir) => {
+		const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+		process.env.PI_CODING_AGENT_DIR = dir;
+		writeFileSync(
+			join(dir, "settings.json"),
+			JSON.stringify({ shellCommandPrefix: "printf 'prefix-output\\n'" }),
+			"utf8",
+		);
+
+		try {
+			const { api, registeredTools, eventHandlers } = createExtensionApiStub();
+			registerToolDisplayOverrides(api, () => DEFAULT_TOOL_DISPLAY_CONFIG);
+			await eventHandlers.before_agent_start?.();
+
+			const bashTool = registeredTools.find((tool) => tool.name === "bash") as ExecutableToolLike | undefined;
+			assert.ok(bashTool, "expected bash override to be registered");
+			const result = await bashTool.execute(
+				"tool-call-2",
+				{ command: "printf 'command-output\\n'" },
+				undefined,
+				undefined,
+				{ cwd: process.cwd() },
+			);
+			assert.equal(getTextOutput(result).trim(), "prefix-output\ncommand-output");
+		} finally {
+			if (previousAgentDir === undefined) {
+				delete process.env.PI_CODING_AGENT_DIR;
+			} else {
+				process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+			}
+		}
+	});
 });
 
 test("registerToolDisplayOverrides drains pending display decorations from early-loading extensions", () => {


### PR DESCRIPTION
## Problem

When `pi-tool-display` overrides Pi's built-in `bash` tool on Windows, the override reconstructs a fresh bash tool instance but does not carry over Pi's configured shell settings from `settings.json`.

In practice, this means a user can set:

```json
{
  "shellPath": "D:\\Tools\\Git\\bin\\bash.exe"
}
```

and core Pi will honor that setting, but once `pi-tool-display` re-registers `bash`, the override falls back to `createBashTool(cwd)` with no `shellPath` or `shellCommandPrefix`.

On Windows, that fallback shell resolution can pick the first `bash.exe` on `PATH`. In the reported case, `where bash.exe` resolved `C:\Windows\System32\bash.exe` before Git Bash, so tool calls ended up launching WSL instead of the configured Git Bash shell.

Result: the session was started from Windows, `shellPath` was configured correctly, but `bash` tool calls still executed through WSL because the extension dropped the shell settings while overriding the built-in tool.

## Root cause

`pi-tool-display` re-registers the built-in `bash` tool for display purposes, but the override path rebuilt it without loading the active Pi agent settings. That lost:

- `shellPath`
- `shellCommandPrefix`

So the extension behavior diverged from core Pi behavior.

## Fix

This change makes the `bash` override load the active Pi agent settings via `resolvePiAgentDir()` and read `settings.json` before constructing the overridden bash tool. The override now passes through:

- `shellPath`
- `shellCommandPrefix`

This keeps the overridden tool aligned with core Pi's shell behavior instead of silently falling back to PATH-based shell discovery.

## Tests

Added regression coverage for both settings passthrough cases:

1. `shellPath` is honored by the overridden `bash` tool
   - test writes a temporary `settings.json` with a missing shell path
   - expected result is the same `Custom shell path not found` failure that core Pi would produce
   - this proves the override is actually using configured `shellPath` instead of ignoring it

2. `shellCommandPrefix` is honored by the overridden `bash` tool
   - test writes a temporary `settings.json` with a prefix command
   - expected output includes both the prefix output and the requested command output

## Additional hardening

While running the test suite, an unrelated capability-detection edge case surfaced in `src/capabilities.ts`: `getCommands()` entries could contain non-string `name` values. The PR guards that path so capability detection does not throw in that case.

## Validation

- `npm ci --ignore-scripts`
- `npm run check`
